### PR TITLE
fifteen char pointers. where will they send us? lets find out.

### DIFF
--- a/Common.h
+++ b/Common.h
@@ -1,7 +1,7 @@
 #ifndef SLIPPI_COMMON_H
 #define SLIPPI_COMMON_H
 #include <stdbool.h>
-#include "../MexTK/mex.h"
+#include "m-ex/MexTK/mex.h"
 
 //#define LOCAL_TESTING
 

--- a/Components/CharPickerDialog.h
+++ b/Components/CharPickerDialog.h
@@ -18,6 +18,8 @@ typedef struct CharPickerDialog_State {
   u32 open_frame_count;
 } CharPickerDialog_State;
 
+typedef struct CharPickerDialog CharPickerDialog;
+
 typedef struct CharPickerDialog {
   GOBJ *gobj;
   JOBJ *root_jobj;
@@ -25,11 +27,11 @@ typedef struct CharPickerDialog {
   CSIcon *char_icons[CPD_LAST_INDEX + 1];
   CharPickerDialog_State state;
 
-  void (*on_close)();
-  u8 (*get_next_color)();
+  void (*on_close)(CharPickerDialog *cpd, u8 is_selection);
+  u8 (*get_next_color)(u8 charId, u8 colorId, int incr);
 } CharPickerDialog;
 
-void SelectRandomChar();
+void SelectRandomChar(CharPickerDialog *cpd);
 
 CharPickerDialog *CharPickerDialog_Init(GUI_GameSetup *gui, void *on_close, void *get_next_color);
 void CharPickerDialog_Free(CharPickerDialog *cpd);

--- a/Core/Notifications/Chat/Text.c
+++ b/Core/Notifications/Chat/Text.c
@@ -30,7 +30,7 @@ int GetGroupIndex(int groupId) {
     return groupIndex;
 }
 
-char *GetHeaderText(int groupId) {
+const char *GetHeaderText(int groupId) {
     int groupIndex = GetGroupIndex(groupId);
     return HEADER_STRINGS[groupIndex];
 }

--- a/Core/Notifications/Chat/Text.h
+++ b/Core/Notifications/Chat/Text.h
@@ -31,7 +31,7 @@ static GXColor MSG_COLORS[] = {
     {201, 195, 135, 255},
 };
 
-static char* HEADER_STRINGS[] = {
+static const char* const HEADER_STRINGS[] = {
     "Page: Up",
     "Page: Left",
     "Page: Right",

--- a/Core/Notifications/Notifications.h
+++ b/Core/Notifications/Notifications.h
@@ -79,6 +79,6 @@ int GetNextNotificationMessageID();
 
 bool CanAddNewMessage();
 
-void UpdateNotificationMessage();
+void UpdateNotificationMessage(GOBJ *gobj);
 
 #endif SLIPPI_CORE_NOTIFICATION_H

--- a/Game/SysText.h
+++ b/Game/SysText.h
@@ -1,7 +1,7 @@
 #ifndef GAME_SYS_TEXT_H
 #define GAME_SYS_TEXT_H
 
-#include "../MexTK/mex.h"
+#include "../m-ex/MexTK/mex.h"
 #include <stdbool.h>
 #include "../Common.h"
 

--- a/Scenes/CSS/Main.c
+++ b/Scenes/CSS/Main.c
@@ -42,4 +42,8 @@ void InitOnlineCSS() {
   }
 }
 
+void DeinitOnlineCSS() {
+  DeinitializeRankedPointers();
+}
+
 #endif SLIPPI_CSS_MAIN_C

--- a/Scenes/CSS/RankInfo/RankInfo.c
+++ b/Scenes/CSS/RankInfo/RankInfo.c
@@ -8,47 +8,126 @@
 #include "../../../Game/SysText.c"
 #include "../../../Slippi.h"
 
-ExiSlippi_GetRank_Response* rankInfoResp;
-JOBJ* rankIconJobj;
-uint ratingUpdateTimer = 0;
-uint ratingChangeLen;  // Rating change sequence length
-uint loaderCount = 0;
-uint loadTimer = 0;
+#define ABS(x) (((x) < 0) ? (-(x)) : (x))
+#define ABSF(x) (((x) < 0.f) ? (-1.f*(x)) : (x))
+#define ZEROS(x) memset(&(x), 0, sizeof(x))
+#define CHECK_FLAG(field, bit) ((field) & (1 << (bit)))
 
-static char BUFFER[24] = {0};
+static const char QUESTION_MARKS[] = "\x81\x48\x81\x48\x81\x48\x81\x48";  // "????"
 
-void GetRankInfo(ExiSlippi_GetRank_Response* resp) {
+static const char * RANK_STRINGS[] = {
+    "PENDING",
+    "BRONZE 1",
+    "BRONZE 2",
+    "BRONZE 3",
+    "SILVER 1",
+    "SILVER 2",
+    "SILVER 3",
+    "GOLD 1",
+    "GOLD 2",
+    "GOLD 3",
+    "PLATINUM 1",
+    "PLATINUM 2",
+    "PLATINUM 3",
+    "DIAMOND 1",
+    "DIAMOND 2",
+    "DIAMOND 3",
+    "MASTER 1",
+    "MASTER 2",
+    "MASTER 3",
+    "GRANDMASTER",
+};
+
+static const GXColors GX_COLORS = {
+  /* WHITE      */ {255, 255, 255, 255},
+  /* GRAY       */ {142, 145, 150, 255},
+  /* RED        */ {255, 0, 0, 255},
+  /* YELLOW     */ {255, 200, 0, 255},
+  /* GREEN      */ {3, 252, 28, 255},
+  /* LIGHT_GRAY */ {170, 173, 178, 255}
+};
+
+static char BUFFER[24];
+
+static ExiSlippi_GetRank_Response rankInfoResp;
+
+static GOBJ* gobj;
+static JOBJ* rankIconJobj;
+
+static uint ratingUpdateTimer; // A timer for tracking animation that starts at 0 and goes up
+static uint ratingChangeLen; // How long the rating change sequence should last in frames
+static uint loaderCount; // How many dots to display (0 == one, 1 == two, 2 == three)
+static uint loadTimer; // A count-up timer that updates loaderCount every 15 frames
+
+static Text*      text;
+static SubtextIDs subtexts;
+static int        lastRatingTextLen; // Used to offset loader
+
+static bool isMenuTransition; // Set to true if we came from the menu, false if we came from in-game
+static bool allowRankChanges; // Set in InitRankInfo
+static u8 lastExecutedStatus; // Fetch status from Slippi Exi Transfer
+
+void InitializeStaticVariables() {
+  // Initialize data to zeros / null / defaults
+  gobj = NULL;
+  rankIconJobj = NULL;
+  text = NULL;
+  ratingUpdateTimer = 0;
+  isMenuTransition = true;
+  allowRankChanges = true;
+  ZEROS(rankInfoResp);
+  ZEROS(BUFFER);
+  ZEROS(subtexts);
+  lastExecutedStatus = LAST_EXECUTED_STATUS_NONE;
+  lastRatingTextLen = 0;
+}
+
+void DeinitializeRankedPointers() {
+  if (rankIconJobj) {
+    JOBJ_RemoveAll(rankIconJobj);
+  }
+  if (gobj) {
+    GObj_DestroyGXLink(gobj);
+    GObj_FreeObject(gobj);
+  }
+  if (text) {
+    Text_Destroy(text);
+  }
+}
+
+void GetRankInfo() {
   // Get cached rank info from rust
-  ExiSlippi_GetRank_Query* q = calloc(sizeof(ExiSlippi_GetRank_Query));
-  q->command = ExiSlippi_Command_GET_RANK;
-  ExiSlippi_Transfer(q, sizeof(ExiSlippi_GetRank_Query), ExiSlippi_TransferMode_WRITE);
-  ExiSlippi_Transfer(resp, sizeof(ExiSlippi_GetRank_Response), ExiSlippi_TransferMode_READ);
-  HSD_Free(q);
+  ExiSlippi_GetRank_Query* query = HSD_MemAlloc(sizeof(ExiSlippi_GetRank_Query));
+  memset(query, 0, sizeof(ExiSlippi_GetRank_Query));
+  query->command = ExiSlippi_Command_GET_RANK;
+  ExiSlippi_Transfer(query, sizeof(ExiSlippi_GetRank_Query), ExiSlippi_TransferMode_WRITE);
+  ExiSlippi_Transfer(&rankInfoResp, sizeof(ExiSlippi_GetRank_Response), ExiSlippi_TransferMode_READ);
+  HSD_Free(query);
 }
 
 void FetchRankInfo() {
   // OSReport("Fetching rank info...\n");
   // Send dolphin command to pull rank data
-  ExiSlippi_FetchRank_Query* q = calloc(sizeof(ExiSlippi_FetchRank_Query));
-  q->command = ExiSlippi_Command_FETCH_RANK;
-  ExiSlippi_Transfer(q, sizeof(ExiSlippi_FetchRank_Query), ExiSlippi_TransferMode_WRITE);
-  HSD_Free(q);
+  ExiSlippi_FetchRank_Query* query = HSD_MemAlloc(sizeof(ExiSlippi_FetchRank_Query));
+  memset(query, 0, sizeof(ExiSlippi_FetchRank_Query));
+  query->command = ExiSlippi_Command_FETCH_RANK;
+  ExiSlippi_Transfer(query, sizeof(ExiSlippi_FetchRank_Query), ExiSlippi_TransferMode_WRITE);
+  HSD_Free(query);
 }
 
 void InitRankInfo() {
-  // Allocate rank info data
-  rankInfoResp = calloc(sizeof(ExiSlippi_GetRank_Response));
+  // Initialize our static variables we use in this file
+  InitializeStaticVariables();
 
   // Load byte from address 0x80479D34. Stores previous minor scene index.
-  u8 previousMinor = *(u8*)0x80479D34;
+  u8 previousMinor = *((u8*)0x80479D34);
   isMenuTransition = previousMinor == 0;
 
   // Get rank info before fetching, this is the previous game's state
-  GetRankInfo(rankInfoResp);
+  GetRankInfo();
 
-  bool localRankVisible = rankInfoResp->visibility & (1 << VISIBILITY_LOCAL);
-  if (!localRankVisible) {
-    // OSReport("rank info disabled %d\n", rankInfoResp->visibility);
+  if (CHECK_FLAG(rankInfoResp.visibility, VISIBILITY_LOCAL)) {
+    // OSReport("rank info disabled %d\n", rankInfoResp.visibility);
     return;
   }
 
@@ -62,19 +141,19 @@ void InitRankInfo() {
 
   // If we are coming from CSS, always show current rank with no animations.
   // We will also allow the rank to change if when we load the CSS initially we are currently fetching or in error
-  allowRankChanges = !isMenuTransition || rankInfoResp->status != RankInfo_FetchStatus_FETCHED;
+  allowRankChanges = !isMenuTransition || rankInfoResp.status != RankInfo_FetchStatus_FETCHED;
 
   // If we are coming from in-game, we should show the current rank in the data at the start because we haven't
   // loaded the new rank data yet. We only show prev rank at the start once we've loaded the new data.
-  InitRankIcon(dt->SlpCSSDatAddress, rankInfoResp->rank);
+  InitRankIcon(dt->SlpCSSDatAddress, rankInfoResp.rank);
   InitRankInfoText(
-      rankInfoResp->rank,
-      rankInfoResp->ratingOrdinal,
-      rankInfoResp->ratingUpdateCount,
-      rankInfoResp->status);
+      rankInfoResp.rank,
+      rankInfoResp.ratingOrdinal,
+      rankInfoResp.ratingUpdateCount,
+      rankInfoResp.status);
 }
 
-void SetRankIcon(u8 rank) {
+void SetRankIcon(SlippiRank rank) {
   if (rankIconJobj) {
     // Set rank icon
     JOBJ_ForEachAnim(rankIconJobj, 6, 0x400, AOBJ_ReqAnim, 1, (float)rank);  // HSD_TypeMask::TOBJ 0x400
@@ -83,47 +162,44 @@ void SetRankIcon(u8 rank) {
   }
 }
 
-
 // Returns length of the rating string
-void SetRankText(u8 rank, float rating, uint matches_played, RankInfo_FetchStatus status) {
+void SetRankText(SlippiRank rank, float rating, uint matchesPlayed, RankInfo_FetchStatus status) {
   // Set rank name string
-  Text_SetText(text, rankSubtextId, RANK_STRINGS[rank]);
-  Text_SetColor(text, rankSubtextId, &GX_COLORS.WHITE);
+  Text_SetText(text, subtexts.rank, RANK_STRINGS[rank]);
+  Text_SetColor(text, subtexts.rank, &GX_COLORS.WHITE);
 
   // OSReport("Rank / rating text being set. Status: %d\n", status);
 
   // If fetching and we have no rank yet, show question marks
   // This will show them both while we are in pending or if a fetch failed. That's fine
-  bool isFetching = status == RankInfo_FetchStatus_FETCHING;
-  if (isFetching && rank == 0) {
+  if ((status == RankInfo_FetchStatus_FETCHING) && rank == 0) {
     // Show question mark if match data is unreported
-    Text_SetText(text, ratingSubtextId, QUESTION_MARKS);
+    Text_SetText(text, subtexts.rating, QUESTION_MARKS);
     // Gray out rating text if elo is pending
-    Text_SetColor(text, ratingSubtextId, &GX_COLORS.GRAY);
+    Text_SetColor(text, subtexts.rating, &GX_COLORS.GRAY);
     // Indicate the string is longer because the question marks are wide
     lastRatingTextLen = 6;
     return;
   }
 
   // Check if the user has completed their placement matches
-  if (matches_played >= PLACEMENT_THRESHOLD) {
+  if (matchesPlayed >= PLACEMENT_THRESHOLD) {
     // Show rating if placed
     sprintf(BUFFER, "%0.1f", rating);
   } else {
     // Show remaining number of sets if not placed
-    sprintf(BUFFER, "%d SETS REQUIRED", 5 - matches_played);
+    sprintf(BUFFER, "%d SETS REQUIRED", 5 - matchesPlayed);
   }
 
-  Text_SetText(text, ratingSubtextId, BUFFER);
-  Text_SetColor(text, ratingSubtextId, &GX_COLORS.LIGHT_GRAY);
+  Text_SetText(text, subtexts.rating, BUFFER);
+  Text_SetColor(text, subtexts.rating, &GX_COLORS.LIGHT_GRAY);
 
   lastRatingTextLen = strlen(BUFFER);
 }
 
-void InitRankIcon(SlpCSSDesc* slpCss, u8 rank) {
-  GOBJ* gobj = GObj_Create(0x4, 0x5, 0x80);
+void InitRankIcon(SlpCSSDesc* slpCss, SlippiRank rank) {
+  gobj = GObj_Create(0x4, 0x5, 0x80);
   rankIconJobj = JOBJ_LoadJoint(slpCss->rankIcons->jobj);
-
   rankIconJobj->trans.X = -9.f;
   rankIconJobj->trans.Y = -12.5f;
   rankIconJobj->scale.X = 2.f;
@@ -145,7 +221,7 @@ void InitRankIcon(SlpCSSDesc* slpCss, u8 rank) {
   GObj_AddGXLink(gobj, GXLink_Common, 1, 129);
 }
 
-void InitRankInfoText(u8 rank, float rating, uint matches_played, RankInfo_FetchStatus status) {
+void InitRankInfoText(SlippiRank rank, float rating, uint matchesPlayed, RankInfo_FetchStatus status) {
   // Create text object for rank info
   text = Text_CreateText(0, 0);
   text->kerning = 1;
@@ -154,27 +230,30 @@ void InitRankInfoText(u8 rank, float rating, uint matches_played, RankInfo_Fetch
   text->scale = (Vec2){0.01, 0.01};
   text->aspect.X *= 2.5;
 
-  // Create rank label text
-  rankLabelSubtextId = Text_AddSubtext(text, -1110, 850, "Rank");
-  Text_SetScale(text, rankLabelSubtextId, 4, 4);
-  Text_SetColor(text, rankLabelSubtextId, &GX_COLORS.GRAY);
+  // Rank Label, i.e. "Rank"
+  subtexts.rankLabel = Text_AddSubtext(text, -1110, 850, "Rank");
+  Text_SetScale(text, subtexts.rankLabel, 4, 4);
+  Text_SetColor(text, subtexts.rankLabel, &GX_COLORS.GRAY);
 
-  // Create rank text
-  rankSubtextId = Text_AddSubtext(text, -640, 1100, "");
-  Text_SetScale(text, rankSubtextId, 4, 4);
-  // Create rating text
-  ratingSubtextId = Text_AddSubtext(text, -640, 1250, "");
-  Text_SetScale(text, ratingSubtextId, 3.5, 3.5);
-  // Set text
-  SetRankText(rank, rating, matches_played, status);
+  // Rank Text, ex. "BRONZE 3", "GRANDMASTER" (can be "Error")
+  subtexts.rank = Text_AddSubtext(text, -640, 1100, "");
+  Text_SetScale(text, subtexts.rank, 4, 4);
 
-  // Initialize rank loader
-  loaderSubtextId = Text_AddSubtext(text, -640, 1224, "");
-  Text_SetScale(text, loaderSubtextId, 4.25, 4.25);
-  Text_SetColor(text, loaderSubtextId, &GX_COLORS.YELLOW);
+  // Rating Text, ex. "2002.5", "994.3" (can be "Failed to get rank", "X SETS REQUIRED", and "????")
+  subtexts.rating = Text_AddSubtext(text, -640, 1250, "");
+  Text_SetScale(text, subtexts.rating, 3.5, 3.5);
+
+  // Set the newly created texts to their appropriate values
+  SetRankText(rank, rating, matchesPlayed, status);
+
+  // Rank Loader, i.e. an oscillation of ".", "..", "...", or empty
+  subtexts.loader = Text_AddSubtext(text, -640, 1224, "");
+  Text_SetScale(text, subtexts.loader, 4.25, 4.25);
+  Text_SetColor(text, subtexts.loader, &GX_COLORS.YELLOW);
 }
 
 void UpdateRankChangeAnim() {
+  // Figure which animation frame we are on after surpassing ratingChangeLen (frame 0 starts at frame ratingChangeLen)
   if (ratingUpdateTimer >= ratingChangeLen) {
     const int rankAnimFrame = ratingUpdateTimer - ratingChangeLen;
     if (rankAnimFrame > 0 && rankAnimFrame < RANK_CHANGE_LEN) {
@@ -185,52 +264,40 @@ void UpdateRankChangeAnim() {
 }
 
 void UpdateRankInfo() {
-  bool enabled = rankInfoResp->visibility & (1 << VISIBILITY_LOCAL);
-  if (!enabled) {
-    return;
-  }
+  // See where allowRankChanges is set for more info about when this happens.
+  if (!allowRankChanges || !CHECK_FLAG(rankInfoResp.visibility, VISIBILITY_LOCAL)) { return; }
 
-  // See where this is set for more info about when this happens.
-  if (!allowRankChanges) {
-    return;
-  }
+  // Make sure our rank info is up to date
+  GetRankInfo();
 
-  // Make sure the rank info is up to date
-  GetRankInfo(rankInfoResp);
-
-  u8 responseStatus = rankInfoResp->status;
-  s8 rank = rankInfoResp->rank;
-
-  if (responseStatus == RankInfo_FetchStatus_FETCHED) {
-    // bool error = rankInfoResp->status == RankInfo_ResponseStatus_ERROR;
-    bool hasChanged = rankInfoResp->ratingChange != 0 || rankInfoResp->rankChange != 0;
-    bool isPlaced = rankInfoResp->ratingUpdateCount >= PLACEMENT_THRESHOLD;
-
+  // If we have finished fetching data called during initialization
+  if (rankInfoResp.status == RankInfo_FetchStatus_FETCHED) {
     // Only initialize the fetched status if we didn't previously process a fetched response status
     if (lastExecutedStatus != LAST_EXECUTED_STATUS_FETCHED) {
       // Determine the duration of the rating increase / decrease
-      float change = rankInfoResp->ratingChange;
-      if (fabs(change) < LOW_RATING_THRESHOLD) {
-        ratingChangeLen = RATING_CHANGE_LEN * 0.25f;
-      } else if (fabs(change) < MED_RATING_THRESHOLD) {
-        ratingChangeLen = RATING_CHANGE_LEN * 0.5f;
+      float change = rankInfoResp.ratingChange;
+      if (ABSF(change) < LOW_RATING_THRESHOLD) {
+        ratingChangeLen = RATING_CHANGE_LEN / 4;
+      } else if (ABSF(change) < MED_RATING_THRESHOLD) {
+        ratingChangeLen = RATING_CHANGE_LEN / 2;
       } else {
         ratingChangeLen = RATING_CHANGE_LEN;
       }
 
       SlippiCSSDataTable* dt = GetSlpCSSDT();
-      // Here we load the "previous" values because we are about to transition from those to the current.
-      uint matchesPlayed = rankInfoResp->ratingUpdateCount;
-      u8 prevRank = rankInfoResp->rank - rankInfoResp->rankChange;
-      float prevRating = rankInfoResp->ratingOrdinal - rankInfoResp->ratingChange;
-      SetRankIcon(prevRank);
-      SetRankText(prevRank, prevRating, matchesPlayed, responseStatus);
 
-      // Clear loader
-      Text_SetText(text, loaderSubtextId, "");
-    } else if (isPlaced) {
+      // Here we load the "previous" values because we are about to transition from those to the current.
+      uint matchesPlayed = rankInfoResp.ratingUpdateCount;
+      SlippiRank prevRank = rankInfoResp.rank - rankInfoResp.rankChange;
+      float prevRating = rankInfoResp.ratingOrdinal - rankInfoResp.ratingChange;
+      SetRankIcon(prevRank);
+      SetRankText(prevRank, prevRating, matchesPlayed, rankInfoResp.status);
+
+      // Clear loader text
+      Text_SetText(text, subtexts.loader, "");
+    } else if (rankInfoResp.ratingUpdateCount >= PLACEMENT_THRESHOLD) {
       UpdateRatingChange();
-      int rankChange = rankInfoResp->rankChange;
+      int rankChange = rankInfoResp.rankChange;
       if (rankChange != 0) {
         UpdateRankChangeAnim();
       }
@@ -238,48 +305,48 @@ void UpdateRankInfo() {
 
     // Allow other states to be initialized again
     lastExecutedStatus = LAST_EXECUTED_STATUS_FETCHED;
-  } else if (responseStatus == RankInfo_FetchStatus_ERROR) {
+  } else if (rankInfoResp.status == RankInfo_FetchStatus_ERROR) {
     // Initialize error state
     if (lastExecutedStatus != LAST_EXECUTED_STATUS_ERROR) {
       // Clear loader
-      Text_SetText(text, loaderSubtextId, "");
+      Text_SetText(text, subtexts.loader, "");
 
       // Dislay rank fetch error
-      Text_SetText(text, rankSubtextId, "Error");
-      Text_SetColor(text, rankSubtextId, &GX_COLORS.WHITE);
-      Text_SetText(text, ratingSubtextId, "Failed to get rank");
-      Text_SetColor(text, ratingSubtextId, &GX_COLORS.RED);
+      Text_SetText(text, subtexts.rank, "Error");
+      Text_SetColor(text, subtexts.rank, &GX_COLORS.WHITE);
+      Text_SetText(text, subtexts.rating, "Failed to get rank");
+      Text_SetColor(text, subtexts.rating, &GX_COLORS.RED);
     }
 
     // Prevent error logic from looping, allow rank initialization again
     lastExecutedStatus = LAST_EXECUTED_STATUS_ERROR;
-  } else if (rankInfoResp->status == RankInfo_FetchStatus_FETCHING) {
+  } else if (rankInfoResp.status == RankInfo_FetchStatus_FETCHING) {
     // Initialize fetching state
     if (lastExecutedStatus != LAST_EXECUTED_STATUS_FETCHING) {
       // Set the rank icon and text values based on what data we previously had. That means loading
       // the "current" values because we haven't loaded the new stuff yet.
-      uint matchesPlayed = rankInfoResp->ratingUpdateCount;
-      SetRankIcon(rankInfoResp->rank);
-      SetRankText(rankInfoResp->rank, rankInfoResp->ratingOrdinal, matchesPlayed, responseStatus);
+      uint matchesPlayed = rankInfoResp.ratingUpdateCount;
+      SetRankIcon(rankInfoResp.rank);
+      SetRankText(rankInfoResp.rank, rankInfoResp.ratingOrdinal, matchesPlayed, rankInfoResp.status);
 
       // Set loader position
       float loaderPosX = -640.f + (lastRatingTextLen * 60.f);
-      Text_SetPosition(text, loaderSubtextId, loaderPosX, 1224);
+      Text_SetPosition(text, subtexts.loader, loaderPosX, 1224);
     }
 
     // Update unreported loader
     if (loadTimer % 15 == 0) {
       switch (loaderCount) {
         case 0: {
-          Text_SetText(text, loaderSubtextId, ".");
+          Text_SetText(text, subtexts.loader, ".");
           break;
         }
         case 1: {
-          Text_SetText(text, loaderSubtextId, "..");
+          Text_SetText(text, subtexts.loader, "..");
           break;
         }
         case 2: {
-          Text_SetText(text, loaderSubtextId, "...");
+          Text_SetText(text, subtexts.loader, "...");
           break;
         }
       }
@@ -295,15 +362,14 @@ void UpdateRankInfo() {
 
 float InterpRating(float ratingOrdinal, float ratingChange) {
   // Percent completion of rating increment
-  float completion = ratingUpdateTimer / (float)ratingChangeLen;
+  float completion = (float)ratingUpdateTimer / (float)ratingChangeLen;
   return (ratingOrdinal - ratingChange) + (ratingChange * completion);
 }
 
 int GetRatingChangeSFX(float ratingChange) {
-  if (rankInfoResp->ratingChange > 0) {
+  if (rankInfoResp.ratingChange > 0) {
     return TICK_UP;
-  }
-  if (rankInfoResp->ratingChange < 0) {
+  } else if (rankInfoResp.ratingChange < 0) {
     return TICK_DOWN;
   } else {
     return 0xD0;
@@ -311,9 +377,9 @@ int GetRatingChangeSFX(float ratingChange) {
 }
 
 int GetRankChangeSFX() {
-  if (rankInfoResp->rankChange > 0) {
+  if (rankInfoResp.rankChange > 0) {
     return RANK_UP_SMALL;
-  } else if (rankInfoResp->rankChange < 0) {
+  } else if (rankInfoResp.rankChange < 0) {
     return RANK_DOWN_SMALL;
   } else {
     return 0xD0;
@@ -325,30 +391,22 @@ void UpdateRatingChange() {
   if (ratingUpdateTimer % 2 == 1 && ratingUpdateTimer < ratingChangeLen) {
     // Calculate rating increment for counting effect
     float displayRating = InterpRating(
-        rankInfoResp->ratingOrdinal,
-        rankInfoResp->ratingChange);
-
+        rankInfoResp.ratingOrdinal,
+        rankInfoResp.ratingChange);
 
     sprintf(BUFFER, "%0.1f", displayRating);
-    Text_SetText(text, ratingSubtextId, BUFFER);
-
-    u8 tickVolume = 0;
-    if (rankInfoResp->ratingChange > 0) {
-      tickVolume = TICK_UP_VOL;
-    }
-    if (rankInfoResp->ratingChange < 0) {
-      tickVolume = TICK_DOWN_VOL;
-    }
+    Text_SetText(text, subtexts.rating, BUFFER);
 
     // Play tick sound effect during rating change
+    u8 tickVolume = rankInfoResp.ratingChange > 0 ? TICK_UP_VOL : TICK_DOWN_VOL;
     SFX_PlayRaw(
-        GetRatingChangeSFX(rankInfoResp->ratingChange),
+        GetRatingChangeSFX(rankInfoResp.ratingChange),
         tickVolume,
         64, 0, 0);
   } else if (ratingUpdateTimer == ratingChangeLen) {
     // Set rating text to exact amount to prevent interp inaccuracies
-    sprintf(BUFFER, "%0.1f", rankInfoResp->ratingOrdinal);
-    Text_SetText(text, ratingSubtextId, BUFFER);
+    sprintf(BUFFER, "%0.1f", rankInfoResp.ratingOrdinal);
+    Text_SetText(text, subtexts.rating, BUFFER);
   }
 
   if (ratingUpdateTimer == ratingChangeLen + RANK_CHANGE_LEN) {
@@ -357,51 +415,51 @@ void UpdateRatingChange() {
   }
 
   if (ratingUpdateTimer < ratingChangeLen + RANK_CHANGE_LEN + RATING_NOTIFICATION_LEN) {
-    if (ratingUpdateTimer == ratingChangeLen + (int)(RANK_CHANGE_LEN / 2) + 1) {
-      // Handle rank-up SFX and show rating change notification
-      if (rankInfoResp->ratingChange != 0) {
+    if (ratingUpdateTimer == ratingChangeLen + (RANK_CHANGE_LEN / 2) + 1) {
+      // Handle rate-up/rate-down SFX and show rating change notification
+      if (rankInfoResp.ratingChange != 0) {
         // Create rating change text
-        char* signString = rankInfoResp->ratingChange > 0 ? "\x81\x7B" : "\x81\x7C";
-        sprintf(BUFFER, "%s%0.1f", signString, fabs(rankInfoResp->ratingChange));
+        char* signString = rankInfoResp.ratingChange > 0 ? "\x81\x7B" : "\x81\x7C";
+        sprintf(BUFFER, "%s%0.1f", signString, ABSF(rankInfoResp.ratingChange));
 
         // Create subtext for rating change
-        ratingChangeSubtextId = Text_AddSubtext(text, -225, 1260, BUFFER);
-        Text_SetScale(text, ratingChangeSubtextId, 3.0, 3.0);
+        subtexts.ratingChange = Text_AddSubtext(text, -225, 1260, BUFFER);
+        Text_SetScale(text, subtexts.ratingChange, 3.0, 3.0);
 
         // Determine text color
-        if (rankInfoResp->ratingChange > 0) {
-          Text_SetColor(text, ratingChangeSubtextId, &GX_COLORS.GREEN);
+        if (rankInfoResp.ratingChange > 0) {
+          Text_SetColor(text, subtexts.ratingChange, &GX_COLORS.GREEN);
           // Play sfx for end of counting
           SFX_PlayRaw(RATING_INCREASE, 255, 64, 0, 0);
         }
-        if (rankInfoResp->ratingChange < 0) {
-          Text_SetColor(text, ratingChangeSubtextId, &GX_COLORS.RED);
+        if (rankInfoResp.ratingChange < 0) {
+          Text_SetColor(text, subtexts.ratingChange, &GX_COLORS.RED);
           // Play sfx for end of counting
           SFX_PlayRaw(RATING_DECREASE, 255, 64, 0, 0);
         }
       } else {
         // In the case where there is no rating change, assume the result did not go through
-        ratingChangeSubtextId = Text_AddSubtext(text, -225, 1260, "result pending");
-        Text_SetScale(text, ratingChangeSubtextId, 3.0, 3.0);
-        Text_SetColor(text, ratingChangeSubtextId, &GX_COLORS.YELLOW);
+        subtexts.ratingChange = Text_AddSubtext(text, -225, 1260, "result pending");
+        Text_SetScale(text, subtexts.ratingChange, 3.0, 3.0);
+        Text_SetColor(text, subtexts.ratingChange, &GX_COLORS.YELLOW);
       }
 
       // Set new rank icon and text
-      if (rankInfoResp->rankChange != 0) {
+      if (rankInfoResp.rankChange != 0) {
         // Update rank icon
-        u8 newRank = rankInfoResp->rank;
+        SlippiRank newRank = rankInfoResp.rank;
         SetRankIcon(newRank);
         // Update rank text
-        float newRating = rankInfoResp->ratingOrdinal;
-        u8 matchesPlayed = rankInfoResp->ratingUpdateCount;
+        float newRating = rankInfoResp.ratingOrdinal;
+        u8 matchesPlayed = rankInfoResp.ratingUpdateCount;
         SetRankText(newRank, newRating, matchesPlayed, RankInfo_FetchStatus_FETCHED);
       }
     }
 
     // Clear notification string after rating change
     if (ratingUpdateTimer == ratingChangeLen + RANK_CHANGE_LEN + RATING_NOTIFICATION_LEN - 1) {
-      if (ratingChangeSubtextId != 0) {
-        Text_SetText(text, ratingChangeSubtextId, "");
+      if (subtexts.ratingChange != 0) {
+        Text_SetText(text, subtexts.ratingChange, "");
       }
     }
   }

--- a/Scenes/CSS/RankInfo/RankInfo.h
+++ b/Scenes/CSS/RankInfo/RankInfo.h
@@ -5,6 +5,34 @@
 #include "../../../Common.h"
 #include "../../../ExiSlippi.h"
 
+// RATING THRESHOLDS
+#define HIGH_RATING_THRESHOLD 35.f
+#define MED_RATING_THRESHOLD 20.f
+#define LOW_RATING_THRESHOLD 10.f
+#define PLACEMENT_THRESHOLD 5
+
+// SFX
+#define RANK_UP_SMALL 0xAA
+#define RANK_UP_BIG 0xAB
+#define RANK_DOWN_SMALL 0xBE
+#define RANK_DOWN_BIG 0xBF
+#define RATING_INCREASE 0x69
+#define RATING_DECREASE 0x19E
+#define TICK_UP_VOL 150
+#define TICK_DOWN_VOL 100
+#define TICK_UP 0xBB
+#define TICK_DOWN 0xEA
+
+// ANIMATION
+#define RATING_CHANGE_LEN 140
+#define RANK_CHANGE_LEN 10
+#define RATING_NOTIFICATION_LEN 200
+#define NARRATOR_LEN 140 /* 2 seconds of 'Choose your character!' */
+
+// RANK FETCH DURATIONS
+#define RETRY_FETCH_0_LEN 120
+#define RETRY_FETCH_1_LEN 420
+
 typedef struct RankInfo {
   u8 visibility;
   u8 status;
@@ -17,12 +45,29 @@ typedef struct RankInfo {
   s8 rankChange;
 } RankInfo;
 
+typedef struct GXColors {
+  GXColor WHITE;
+  GXColor GRAY;
+  GXColor RED;
+  GXColor YELLOW;
+  GXColor GREEN;
+  GXColor LIGHT_GRAY;
+} GXColors;
+
+typedef struct SubtextIDs {
+  int loader;
+  int ratingChange;
+  int rank;
+  int rating;
+  int rankLabel;
+} SubtextIDs;
+
 enum RankVisibility {
   VISIBILITY_LOCAL,
   VISIBILITY_OPPONENT
 };
 
-enum SlippiRank {
+typedef enum SlippiRank {
   RANK_UNRANKED,
   RANK_BRONZE_1,
   RANK_BRONZE_2,
@@ -44,7 +89,7 @@ enum SlippiRank {
   RANK_MASTER_3,
   RANK_GRANDMASTER,
   RANK_COUNT
-};
+} SlippiRank;
 
 enum LastExecutedStatus {
   LAST_EXECUTED_STATUS_NONE,
@@ -53,93 +98,9 @@ enum LastExecutedStatus {
   LAST_EXECUTED_STATUS_ERROR
 };
 
-static const char QUESTION_MARKS[] = "\x81\x48\x81\x48\x81\x48\x81\x48";  // "????"
-
-static const char * RANK_STRINGS[] = {
-    "PENDING",
-    "BRONZE 1",
-    "BRONZE 2",
-    "BRONZE 3",
-    "SILVER 1",
-    "SILVER 2",
-    "SILVER 3",
-    "GOLD 1",
-    "GOLD 2",
-    "GOLD 3",
-    "PLATINUM 1",
-    "PLATINUM 2",
-    "PLATINUM 3",
-    "DIAMOND 1",
-    "DIAMOND 2",
-    "DIAMOND 3",
-    "MASTER 1",
-    "MASTER 2",
-    "MASTER 3",
-    "GRANDMASTER",
-};
-
-Text *text;
-int loaderSubtextId;
-int ratingChangeSubtextId;
-int rankSubtextId;
-int ratingSubtextId;
-int rankLabelSubtextId;
-int lastRatingTextLen;  // Used to offset loader
-
-bool isMenuTransition = true;  // true if we came from the menu. false if we came from in-game
-bool allowRankChanges = true;
-u8 lastExecutedStatus = LAST_EXECUTED_STATUS_NONE;
-
-const float HIGH_RATING_THRESHOLD = 35.f;
-const float MED_RATING_THRESHOLD = 20.f;
-const float LOW_RATING_THRESHOLD = 10.f;
-const u8 PLACEMENT_THRESHOLD = 5;
-
-// SFX
-const int RANK_UP_SMALL = 0xAA;
-const int RANK_UP_BIG = 0xAB;
-const int RANK_DOWN_SMALL = 0xBE;
-const int RANK_DOWN_BIG = 0xBF;
-
-const int RATING_INCREASE = 0x69;
-const int RATING_DECREASE = 0x19E;
-
-const int TICK_UP_VOL = 150;
-const int TICK_DOWN_VOL = 100;
-const int TICK_UP = 0xBB;
-const int TICK_DOWN = 0xEA;
-
-// ANIMATION
-const int RATING_CHANGE_LEN = 140;
-const int RANK_CHANGE_LEN = 10;
-const int RATING_NOTIFICATION_LEN = 200;
-const int NARRATOR_LEN = 140;  // 2 seconds of 'Choose your character!'
-
-// RANK FETCH DURATIONS
-const int RETRY_FETCH_0_LEN = 120;
-const int RETRY_FETCH_1_LEN = 420;
-
-void InitRankInfoText(u8 rank, float rating, uint matches_played, RankInfo_FetchStatus status);
-void InitRankIcon(SlpCSSDesc *slpCss, u8 rank);
+void InitRankInfoText(SlippiRank rank, float rating, uint matches_played, RankInfo_FetchStatus status);
+void InitRankIcon(SlpCSSDesc *slpCss, SlippiRank rank);
 void UpdateRatingChange();
 void UpdateRankInfo();
-
-typedef struct GXColors {
-  GXColor WHITE;
-  GXColor GRAY;
-  GXColor RED;
-  GXColor YELLOW;
-  GXColor GREEN;
-  GXColor LIGHT_GRAY;
-} GXColors;
-
-static const GXColors GX_COLORS = {
-  /* WHITE      */ {255, 255, 255, 255},
-  /* GRAY       */ {142, 145, 150, 255},
-  /* RED        */ {255, 0, 0, 255},
-  /* YELLOW     */ {255, 200, 0, 255},
-  /* GREEN      */ {3, 252, 28, 255},
-  /* LIGHT_GRAY */ {170, 173, 178, 255}
-};
 
 #endif SLIPPI_CSS_RANK_INFO_H

--- a/Scenes/CSS/RankInfo/RankInfo.h
+++ b/Scenes/CSS/RankInfo/RankInfo.h
@@ -1,6 +1,7 @@
 #ifndef SLIPPI_CSS_RANK_INFO_H
 #define SLIPPI_CSS_RANK_INFO_H
 
+#include "../../../Slippi.h"
 #include "../../../Common.h"
 #include "../../../ExiSlippi.h"
 
@@ -52,7 +53,9 @@ enum LastExecutedStatus {
   LAST_EXECUTED_STATUS_ERROR
 };
 
-static char *RANK_STRINGS[] = {
+static const char QUESTION_MARKS[] = "\x81\x48\x81\x48\x81\x48\x81\x48";  // "????"
+
+static const char * RANK_STRINGS[] = {
     "PENDING",
     "BRONZE 1",
     "BRONZE 2",
@@ -120,5 +123,23 @@ void InitRankInfoText(u8 rank, float rating, uint matches_played, RankInfo_Fetch
 void InitRankIcon(SlpCSSDesc *slpCss, u8 rank);
 void UpdateRatingChange();
 void UpdateRankInfo();
+
+typedef struct GXColors {
+  GXColor WHITE;
+  GXColor GRAY;
+  GXColor RED;
+  GXColor YELLOW;
+  GXColor GREEN;
+  GXColor LIGHT_GRAY;
+} GXColors;
+
+static const GXColors GX_COLORS = {
+  /* WHITE      */ {255, 255, 255, 255},
+  /* GRAY       */ {142, 145, 150, 255},
+  /* RED        */ {255, 0, 0, 255},
+  /* YELLOW     */ {255, 200, 0, 255},
+  /* GREEN      */ {3, 252, 28, 255},
+  /* LIGHT_GRAY */ {170, 173, 178, 255}
+};
 
 #endif SLIPPI_CSS_RANK_INFO_H

--- a/Scenes/CSS/SheikSelector.c
+++ b/Scenes/CSS/SheikSelector.c
@@ -14,7 +14,7 @@ void SetSelectedChar(u8 ckind) {
   CssData->data.data.players[playerIndex].c_kind = ckind;
 
   // Change nametag to say Sheik or Zelda
-  CSSIcon *iconData = 0x803f0cc8;
+  CSSIcon *iconData = (CSSIcon*)0x803f0cc8;
   iconData->char_kind = ckind;
 
   SFX_getCharacterNameAnnouncer(ckind);
@@ -51,6 +51,36 @@ void InitSheikSelector() {
   GObj_AddGXLink(selectorGobj, GXLink_Common, 1, 129);
 
   isInNameEntry = IsOnCSSNameEntryScreen();
+}
+
+void UpdateSelectorAlphas(bool zeldaHovered, bool sheikHovered) {
+  JOBJ *zeldaIcon = selectorJobj->child;
+  JOBJ *sheikIcon = selectorJobj->child->sibling;
+
+  u8 selectedChar = GetSelectedChar();
+
+  bool sheikSelected = selectedChar == CKIND_SHEIK;
+  bool zeldaSelected = selectedChar == CKIND_ZELDA;
+
+  float zeldaAlpha = INACTIVE_ALPHA;
+  float sheikAlpha = INACTIVE_ALPHA;
+
+  if (zeldaHovered) {
+    zeldaAlpha = HOVER_ALPHA;
+  }
+  if (sheikHovered) {
+    sheikAlpha = HOVER_ALPHA;
+  }
+
+  if (zeldaSelected) {
+    zeldaAlpha = ACTIVE_ALPHA;
+  }
+  if (sheikSelected) {
+    sheikAlpha = ACTIVE_ALPHA;
+  }
+
+  JOBJ_SetAllAlpha(zeldaIcon, zeldaAlpha);
+  JOBJ_SetAllAlpha(sheikIcon, sheikAlpha);
 }
 
 void UpdateSheikSelector() {
@@ -129,34 +159,4 @@ void UpdateSheikSelector() {
   }
 
   UpdateSelectorAlphas(zeldaHovered, sheikHovered);
-}
-
-void UpdateSelectorAlphas(bool zeldaHovered, bool sheikHovered) {
-  JOBJ *zeldaIcon = selectorJobj->child;
-  JOBJ *sheikIcon = selectorJobj->child->sibling;
-
-  u8 selectedChar = GetSelectedChar();
-
-  bool sheikSelected = selectedChar == CKIND_SHEIK;
-  bool zeldaSelected = selectedChar == CKIND_ZELDA;
-
-  float zeldaAlpha = INACTIVE_ALPHA;
-  float sheikAlpha = INACTIVE_ALPHA;
-
-  if (zeldaHovered) {
-    zeldaAlpha = HOVER_ALPHA;
-  }
-  if (sheikHovered) {
-    sheikAlpha = HOVER_ALPHA;
-  }
-
-  if (zeldaSelected) {
-    zeldaAlpha = ACTIVE_ALPHA;
-  }
-  if (sheikSelected) {
-    sheikAlpha = ACTIVE_ALPHA;
-  }
-
-  JOBJ_SetAllAlpha(zeldaIcon, zeldaAlpha);
-  JOBJ_SetAllAlpha(sheikIcon, sheikAlpha);
 }

--- a/Scenes/CSS/SheikSelector.h
+++ b/Scenes/CSS/SheikSelector.h
@@ -1,4 +1,5 @@
 #include "../../Slippi.h"
+#include "../../Common.h"
 
 typedef struct CSSIcon {
   u8 ft_hudindex;  // 0x00 - used for getting combo count @ 8025C0C4

--- a/Scenes/CSS/SlippiCSSSetup.c
+++ b/Scenes/CSS/SlippiCSSSetup.c
@@ -3,18 +3,24 @@
 
 #include "Main.c"
 
-//Runs every frame during CSS
+// Sanity check gate
+static bool has_initialized = false;
+
+// Runs every frame during CSS
 void minor_think() {
     void (*CSS_think)() = (void *) 0x802669F4;
     CSS_think();
-    UpdateOnlineCSS();
+    if (has_initialized) {
+        UpdateOnlineCSS();
+    }
 }
 
-//Runs when CSS is loaded
+// Runs when CSS is loaded
 void minor_load() {
     void (*CSS_load)() = (void *) 0x8026688C;
     CSS_load();
     InitOnlineCSS();
+    has_initialized = true;
     // OSReport("CSS_load\n");
 }
 
@@ -22,6 +28,8 @@ void minor_load() {
 void minor_exit() {
     void (*CSS_exit)() = (void *) 0x80266D70;
     CSS_exit();
+    DeinitOnlineCSS();
+    has_initialized = false;
     // OSReport("CSS_exit\n");
 }
 

--- a/Slippi.h
+++ b/Slippi.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 
-#include "../MexTK/mex.h"
+#include "m-ex/MexTK/mex.h"
 
 #define PACK true
 #define ALIGN true

--- a/build.bat
+++ b/build.bat
@@ -1,11 +1,71 @@
-"m-ex/MexTK/MexTK.exe" -ff -i "Scenes/Ranked/GameSetup.c" "Components/CharStageBoxSelector.c" "Components/CharStageIcon.c" "Components/Button.c" "Components/FlatTexture.c" "Components/RightArrow.c" "Components/CharPickerDialog.c" "Components/StockIcon.c" "Components/GameResult.c" "Components/TurnIndicator.c" "Game/Characters.c" ^
--s mnFunction ^
--o "output/GameSetup.dat" ^
--t "m-ex/MexTK/mnFunction.txt" ^
--q -ow -c -l "melee.link"
+@ECHO OFF
 
-"m-ex/MexTK/MexTK.exe" -ff -i "Scenes/CSS/SlippiCSSSetup.c" ^
--s mnFunction ^
--o "output/SlippiCSS.dat" ^
--t "m-ex/MexTK/mnFunction.txt" ^
--q -ow -c -l "melee.link"
+SET "OUTPUT_FOLDER=output"
+
+:: Necessary prerequisites: devkitPPC and MexTK ----------------------
+
+IF NOT EXIST "C:\devkitPro\devkitPPC\bin\powerpc-eabi-gcc.exe" (
+        ECHO ERROR: Compiler not found at C:\devkitPro\devkitPPC\bin\powerpc-eabi-gcc.exe
+        ECHO        You must install devkitPro at the root. If you have already installed
+        ECHO        it elsewhere, maybe you can symlink the folder to the root?
+        EXIT /B 1
+) ELSE (
+        ECHO Found powerpc-eabi-gcc.exe!
+)
+
+IF NOT EXIST "m-ex\MexTK\MexTK.exe" (
+        ECHO ERROR: MexTK.exe not found! Did you git submodules?
+        ECHO        Try running: "git submodule update --init --recursive"
+        EXIT /B 2
+) ELSE (
+        ECHO Found MexTK.exe!
+)
+
+IF NOT EXIST "%OUTPUT_FOLDER%" (
+    ECHO Creating output directory "%OUTPUT_FOLDER%"...
+    MKDIR "%OUTPUT_FOLDER%"
+)
+
+:: GameSetup.dat -----------------------------------------------------
+
+ECHO Building GameSetup...
+
+SET SOURCES="Scenes/Ranked/GameSetup.c"
+SET SOURCES=%SOURCES% "Components/CharStageBoxSelector.c"
+SET SOURCES=%SOURCES% "Components/CharStageIcon.c"
+SET SOURCES=%SOURCES% "Components/Button.c"
+SET SOURCES=%SOURCES% "Components/FlatTexture.c"
+SET SOURCES=%SOURCES% "Components/RightArrow.c"
+SET SOURCES=%SOURCES% "Components/CharPickerDialog.c"
+SET SOURCES=%SOURCES% "Components/StockIcon.c"
+SET SOURCES=%SOURCES% "Components/GameResult.c"
+SET SOURCES=%SOURCES% "Components/TurnIndicator.c"
+SET SOURCES=%SOURCES% "Game/Characters.c"
+
+SET FN_TYPE=mnFunction
+SET FN_FILE=m-ex/MexTK/mnFunction.txt
+SET LINK=melee.link
+SET OUTPUT=%OUTPUT_FOLDER%/GameSetup.dat
+
+SET COMMAND=m-ex\MexTK\MexTK.exe -ff -i %SOURCES% -s %FN_TYPE% -o "%OUTPUT%" -t "%FN_FILE%" -q -ow -c -l "%LINK%"
+ECHO %COMMAND%
+%COMMAND%
+
+:: SlippiCSS.dat -----------------------------------------------------
+
+ECHO Building SlippiCSS...
+
+SET SOURCES="Scenes/CSS/SlippiCSSSetup.c"
+
+SET FN_TYPE=mnFunction
+SET FN_FILE=m-ex/MexTK/mnFunction.txt
+SET LINK=melee.link
+SET OUTPUT=%OUTPUT_FOLDER%/SlippiCSS.dat
+
+SET COMMAND=m-ex\MexTK\MexTK.exe -ff -i %SOURCES% -s %FN_TYPE% -o "%OUTPUT%" -t "%FN_FILE%" -q -ow -c -l "%LINK%"
+ECHO %COMMAND%
+%COMMAND%
+
+:: Exit --------------------------------------------------------------
+
+EXIT /B 0


### PR DESCRIPTION
**NOTE**: Not ready for merge, opening request as a heads up / discussion platform. Still working on it, need to ensure the compiled binaries are functional / work / etc. Also take in any other work that seems necessary or suggested / requested, etc 

# Type, types, types
Half of this is maintenance work required to get this to compile with the latest devkitPro on my machine, half of this is fixing things that made me question how this worked in the first place (not to blame anyone, `char` pointers and arrays are a headache)

## In short

- `static` `const` `static` `const` `static` `const`
- Missing Types.
- Did you know `char* my_array[64];` is an array of 64 `char` pointers?

## Changes

### Reference of Self
Forward declaration of `CharPickerDialog` to allow self reference pointer in `on_close`. Complete arguments for function pointer typing as defined elsewhere in the project.

```diff
+ typedef struct CharPickerDialog CharPickerDialog;
+ 
  typedef struct CharPickerDialog {
    GOBJ *gobj;
    JOBJ *root_jobj;
    JOBJSet *jobj_set;
    CSIcon *char_icons[CPD_LAST_INDEX + 1];
    CharPickerDialog_State state;
  
-   void (*on_close)();
-   u8 (*get_next_color)();
+   void (*on_close)(CharPickerDialog *cpd, u8 is_selection);
+   u8 (*get_next_color)(u8 charId, u8 colorId, int incr);
  } CharPickerDialog;

- void SelectRandomChar();
+ void SelectRandomChar(CharPickerDialog *cpd)
```

### static const static const
These should never change. Mirror necessary changes in functions that refer to them / ingest them / return them as well.

```diff
- static char* HEADER_STRINGS[] = {
+ static const char* const HEADER_STRINGS[] = {
    "Page: Up",
    "Page: Left",
    "Page: Right",
```

```diff
- char *GetHeaderText(int groupId) {
+ const char *GetHeaderText(int groupId) {
-     int groupIndex = GetGroupIndex(groupId);
+     return HEADER_STRINGS[groupIndex];
}
```

### String Buffer
Add a reusable static `char BUFFER[24]` for passing to `Text_SetText` and `sprintf`

These colors should be `static` `const`. Move them to the header as well, no reason to keep them here.

```diff
  uint loaderCount = 0;
  uint loadTimer = 0;

- const GXColor white = {255, 255, 255, 255};
- const GXColor gray = {142, 145, 150, 255};
- const GXColor red = {255, 0, 0, 255};
- const GXColor yellow = {255, 200, 0, 255};
- const GXColor green = {3, 252, 28, 255};
- const GXColor lightGray = {170, 173, 178, 255};
+ static char BUFFER[24] = {0};

  void GetRankInfo(ExiSlippi_GetRank_Response* resp) {
    // Get cached rank info from rust
```

### Array of Fifteen `char` Pointers

You'd think `char* rankString[15]` is a pointer to a `char[15]` array that lives on the stack. Nope. You just pass the handle and it automatically works as a pointer that way. This is an array of 15 `char` pointers that point to \~garbage\~ (likely). The only reason this works (somehow, I think) is because the root of the 15 `char` pointers _is_ a pointer to a `char`, so you are still technically giving it a `char*`. Where does it point? lol. somehow `sprintf` is writing to whereever it is pointing and not exploding. I have no idea how this worked before. 

No need to `sprintf` the strings that are already defined either. 

(This is all assuming this is not to avoid some asinine wii-specific-workaround-in-memory-bullshit I'm missing)

```diff
  // Returns length of the rating string
  void SetRankText(u8 rank, float rating, uint matches_played, RankInfo_FetchStatus status) {
    // Set rank name string
-   char* rankString[15];
-   sprintf(rankString, RANK_STRINGS[rank]);
- 
-   Text_SetText(text, rankSubtextId, rankString);
-   Text_SetColor(text, rankSubtextId, &white);
+   Text_SetText(text, rankSubtextId, RANK_STRINGS[rank]);
+   Text_SetColor(text, rankSubtextId, &GX_COLORS.WHITE);
  
    // OSReport("Rank / rating text being set. Status: %d\n", status);
 
```

### static const static const. more.

Moved question marks to header as `static const char[]`. Get to see usage of the `static const GXColors GX_COLORS`

```diff
  if (isFetching && rank == 0) {
    // Show question mark if match data is unreported
-   char* questionMarks = "\x81\x48\x81\x48\x81\x48\x81\x48";  // "????"
-
+   Text_SetText(text, ratingSubtextId, QUESTION_MARKS);
    // Gray out rating text if elo is pending
-   Text_SetText(text, ratingSubtextId, questionMarks);
-   Text_SetColor(text, ratingSubtextId, &gray);
-
+   Text_SetColor(text, ratingSubtextId, &GX_COLORS.GRAY);
    // Indicate the string is longer because the question marks are wide
    lastRatingTextLen = 6;
    return;
  }
  ```

More of the same in the rest of this. Planning on working on this more later. Feel free to comment or ping me on Discord to inform me about whatever might be important to take into consideration.